### PR TITLE
Add simple whitelist strategy

### DIFF
--- a/src/voting-strategies/WhitelistStrategy.sol
+++ b/src/voting-strategies/WhitelistStrategy.sol
@@ -5,26 +5,50 @@ pragma solidity ^0.8.15;
 import "../interfaces/IVotingStrategy.sol";
 
 contract WhitelistStrategy is IVotingStrategy {
-    mapping(address => uint256) public members;
-
     struct Member {
         address addy;
         uint256 vp;
     }
 
-    constructor(Member[] memory _members) {
-        for (uint256 i = 0; i < _members.length; i++) {
-            Member memory member = _members[i];
-            members[member.addy] = member.vp;
+    /**
+     * @notice  Binary search through `members` to find the voting power of `voterAddress`
+     * @param   voterAddress  The voter address
+     * @param   params  The list of members. Needs to be sorted in ascending `addy` order
+     * @return  uint256  The voting power of `voterAddress` if it exists: else 0
+     */
+    function _getVotingPower(address voterAddress, bytes calldata params) internal returns (uint256) {
+        Member[] memory members = abi.decode(params, (Member[]));
+
+        uint256 high = members.length - 1;
+        uint256 low = 0;
+        uint256 mid;
+        address currentAddress;
+
+        while (low < high) {
+            mid = (high + low) / 2; // Expecting high and low to never overflow
+            currentAddress = members[mid].addy;
+
+            if (currentAddress < voterAddress) {
+                low = mid + 1;
+            } else {
+                high = mid;
+            }
+        }
+        if (high > members.length) {
+            return (0);
+        } else if (members[high].addy == voterAddress) {
+            return (members[high].vp);
+        } else {
+            return (0);
         }
     }
 
     function getVotingPower(
         uint32 /* timestamp */,
         address voterAddress,
-        bytes calldata /* params */,
+        bytes calldata params, // Need to be sorted by ascending `addy`s
         bytes calldata /* userParams */
     ) external override returns (uint256) {
-        return members[voterAddress];
+        return _getVotingPower(voterAddress, params);
     }
 }

--- a/test/WhitelistStrategy.t.sol
+++ b/test/WhitelistStrategy.t.sol
@@ -8,13 +8,44 @@ contract WhitelistStrategyTest is Test {
     WhitelistStrategy public whitelistStrategy;
 
     function testWhitelistVotingPower() public {
-        WhitelistStrategy.Member[] memory members = new WhitelistStrategy.Member[](2);
-        members[0] = WhitelistStrategy.Member(address(42), 21);
-        members[1] = WhitelistStrategy.Member(address(1337), 123);
-        whitelistStrategy = new WhitelistStrategy(members);
+        WhitelistStrategy.Member[] memory members = new WhitelistStrategy.Member[](3);
+        members[0] = WhitelistStrategy.Member(address(1), 11);
+        members[1] = WhitelistStrategy.Member(address(3), 33);
+        members[2] = WhitelistStrategy.Member(address(5), 55);
+        whitelistStrategy = new WhitelistStrategy();
 
-        assertEq(whitelistStrategy.getVotingPower(0, members[0].addy, "", ""), members[0].vp);
-        assertEq(whitelistStrategy.getVotingPower(0, members[1].addy, "", ""), members[1].vp);
-        assertEq(whitelistStrategy.getVotingPower(0, address(1), "", ""), 0);
+        bytes memory params = abi.encode(members);
+
+        assertEq(whitelistStrategy.getVotingPower(0, members[0].addy, params, ""), members[0].vp);
+        assertEq(whitelistStrategy.getVotingPower(0, members[1].addy, params, ""), members[1].vp);
+        assertEq(whitelistStrategy.getVotingPower(0, members[2].addy, params, ""), members[2].vp);
+
+        // Index 0
+        assertEq(whitelistStrategy.getVotingPower(0, address(0), params, ""), 0);
+        // Index 2
+        assertEq(whitelistStrategy.getVotingPower(0, address(2), params, ""), 0);
+        // 4
+        assertEq(whitelistStrategy.getVotingPower(0, address(4), params, ""), 0);
+        // Last index
+        assertEq(whitelistStrategy.getVotingPower(0, address(6), params, ""), 0);
+    }
+
+    function testWhitelistVotingPowerSmall() public {
+        WhitelistStrategy.Member[] memory members = new WhitelistStrategy.Member[](3);
+        members[0] = WhitelistStrategy.Member(address(1), 11);
+        members[1] = WhitelistStrategy.Member(address(3), 33);
+        whitelistStrategy = new WhitelistStrategy();
+
+        bytes memory params = abi.encode(members);
+
+        assertEq(whitelistStrategy.getVotingPower(0, members[0].addy, params, ""), members[0].vp);
+        assertEq(whitelistStrategy.getVotingPower(0, members[1].addy, params, ""), members[1].vp);
+
+        // Index 0
+        assertEq(whitelistStrategy.getVotingPower(0, address(0), params, ""), 0);
+        // Index 2
+        assertEq(whitelistStrategy.getVotingPower(0, address(2), params, ""), 0);
+        // Last index
+        assertEq(whitelistStrategy.getVotingPower(0, address(4), params, ""), 0);
     }
 }


### PR DESCRIPTION
Adds a very simple whitelist strategy.
No merkle-thingy because I want to get a simple version out in case UI/UX needs it for easy integration.

Should we add it as `Ownable` and add `addMember` / `removeMember` to make it more flexible?

Closes #23 #1 