### PR TITLE
fix: replace executed boolean with counter on vanilla execution strategy

### DIFF
--- a/src/execution-strategies/VanillaExecutionStrategy.sol
+++ b/src/execution-strategies/VanillaExecutionStrategy.sol
@@ -9,6 +9,6 @@ contract VanillaExecutionStrategy is IExecutionStrategy {
 
     // solhint-disable no-unused-vars
     function execute(ProposalOutcome proposalOutcome, bytes memory executionParams) external override {
-            numExecuted++;
+        numExecuted++;
     }
 }


### PR DESCRIPTION
The `executed` boolean prevented the strategy from being reused. Which isn't very useful for testing with.