### PR TITLE
refactor: use only space modifier

### DIFF
--- a/src/execution-strategies/AvatarExecutionStrategy.sol
+++ b/src/execution-strategies/AvatarExecutionStrategy.sol
@@ -9,7 +9,6 @@ import "../utils/SpaceManager.sol";
 /// @title Avatar Execution Strategy - An Execution strategy that executes transactions on an Avatar contract
 /// @dev An Avatar contract is any contract that implements the IAvatar interface, eg a Gnosis Safe.
 contract AvatarExecutionStrategy is SpaceManager, SimpleQuorumExecutionStrategy {
-    error SpaceNotEnabled();
     error TransactionsFailed();
 
     /// @dev Emitted each time a new Avatar Execution Strategy is deployed.
@@ -56,8 +55,7 @@ contract AvatarExecutionStrategy is SpaceManager, SimpleQuorumExecutionStrategy 
     ///         Must be called by a whitelisted space contract.
     /// @param proposal The proposal to execute.
     /// @param executionParams The encoded transactions to execute.
-    function execute(Proposal memory proposal, bytes memory executionParams) external override {
-        if (spaces[msg.sender] == false) revert SpaceNotEnabled();
+    function execute(Proposal memory proposal, bytes memory executionParams) external override onlySpace(msg.sender) {
         _execute(executionParams);
     }
 

--- a/src/utils/SpaceManager.sol
+++ b/src/utils/SpaceManager.sol
@@ -47,4 +47,9 @@ contract SpaceManager is OwnableUpgradeable {
     function isSpaceEnabled(address space) public view returns (bool) {
         return spaces[space];
     }
+
+    modifier onlySpace(address callerAddress) {
+        if (!isSpaceEnabled(callerAddress)) revert InvalidSpace();
+        _;
+    }
 }

--- a/test/AvatarExecutionStrategy.t.sol
+++ b/test/AvatarExecutionStrategy.t.sol
@@ -8,7 +8,6 @@ import "../src/execution-strategies/AvatarExecutionStrategy.sol";
 import "../src/types.sol";
 
 contract AvatarExecutionStrategyTest is SpaceTest {
-    error SpaceNotEnabled();
     error TransactionsFailed();
     error InvalidSpace();
 
@@ -217,7 +216,7 @@ contract AvatarExecutionStrategyTest is SpaceTest {
         _vote(author, proposalId, Choice.For, userVotingStrategies);
         vm.warp(block.timestamp + space.maxVotingDuration());
 
-        vm.expectRevert(SpaceNotEnabled.selector);
+        vm.expectRevert(InvalidSpace.selector);
         space.execute(proposalId, abi.encode(transactions));
     }
 


### PR DESCRIPTION
closes https://github.com/snapshot-labs/sx-evm/issues/37

Cleaner to use a modifier here as it keeps the `SpaceManager` code more encapsulated