### PR TITLE
chore: separate job for test and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,10 @@ jobs:
       - name: "Install the Node.js dependencies"
         run: "yarn install --immutable"
 
-      - name: "Show the Foundry config"
-        run: "forge config"
-
       - name: "Run coverage"
         run: "yarn coverage"
 
-      - uses: codecov/codecov-action@v3
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "clean": "rimraf cache out",
+    "coverage": "forge coverage",
     "lint": "yarn lint:sol && yarn prettier:check",
     "lint:sol": "solhint \"{src,test,script}/**/*.sol\"",
     "prettier:check": "prettier --check \"**/*.{json,md,sol,yml}\"",


### PR DESCRIPTION
Parallelizes CI for lint and test and shows different checks for each. Not a requirement but I think its better this way.