### PR TITLE
chore: codecov config with threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,10 @@
 ignore:
   - "test"
   - "script"
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%


### PR DESCRIPTION
prevents codecov from failing the CI when there are small updates that dont require and test changes but lead to a change in the coverage %. 