### PR TITLE
audit: Optimize ActiveProposalLimiter storage reads

### DIFF
--- a/src/utils/ActiveProposalsLimiter.sol
+++ b/src/utils/ActiveProposalsLimiter.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.18;
 /// @title Active Proposals Limiter Proposal Validation Module
 /// @notice This module can be used to limit the number of active proposals per author.
 abstract contract ActiveProposalsLimiter {
+    /// @dev Active proposal data stored for each author in a space.
     struct PackedData {
         uint32 activeProposals;
         uint32 lastUpdate;
@@ -13,7 +14,7 @@ abstract contract ActiveProposalsLimiter {
     /// @notice Thrown when the maximum number of active proposals per user is set to 0.
     error MaxActiveProposalsCannotBeZero();
 
-    /// @dev Mapping that stores a data struct for each space.
+    /// @dev Mapping that stores a data struct for each author in a space.
     mapping(address space => mapping(address author => PackedData)) private usersPackedData;
 
     /// @dev Validates an author by checking if they have reached the maximum number of active proposals at the current timestamp.


### PR DESCRIPTION
closes #220 

cache the struct in memory, perform the checks and updates in memory, then finally write the memory struct back to storage. 