### PR TITLE
Add Selected Strategies Option

### DIFF
--- a/src/Space.sol
+++ b/src/Space.sol
@@ -234,7 +234,8 @@ contract Space is ISpace, Initializable, IERC4824, UUPSUpgradeable, OwnableUpgra
             FinalizationStatus.Pending,
             executionPayloadHash,
             activeVotingStrategies,
-            selectedVotingStrategies
+            selectedVotingStrategies,
+            selectedVotingStrategiesIndices
         );
 
         proposals[nextProposalId] = proposal;

--- a/src/interfaces/IERC4824.sol
+++ b/src/interfaces/IERC4824.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.18;
+pragma solidity 0.8.19;
 
 /// @title EIP-4824 Common Interfaces for DAOs
 /// @notice See https://eips.ethereum.org/EIPS/eip-4824

--- a/src/interfaces/space/ISpaceActions.sol
+++ b/src/interfaces/space/ISpaceActions.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.18;
 
-import { Choice, IndexedStrategy, Strategy, InitializeCalldata } from "src/types.sol";
+import { Choice, IndexedStrategy, Strategy, InitializeCalldata } from "../../types.sol";
 
 /// @title Space Actions
 /// @notice User focused actions that can be performed on a space.

--- a/src/interfaces/space/ISpaceActions.sol
+++ b/src/interfaces/space/ISpaceActions.sol
@@ -31,11 +31,13 @@ interface ISpaceActions {
     /// @param   executionStrategy  The execution strategy for the proposal,
     ///          consisting of a strategy address and an execution payload.
     /// @param   userProposalValidationParams  The user provided parameters for proposal validation.
+    /// @param   selectedVotingStrategyIndices The indices of voting strategies to use for this specific proposal. Empty array yields all active.
     function propose(
         address author,
         string calldata metadataURI,
         Strategy calldata executionStrategy,
-        bytes calldata userProposalValidationParams
+        bytes calldata userProposalValidationParams,
+        uint8[] calldata selectedVotingStrategyIndices 
     ) external;
 
     /// @notice  Casts a vote.

--- a/src/interfaces/space/ISpaceEvents.sol
+++ b/src/interfaces/space/ISpaceEvents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-import { IndexedStrategy, Proposal, Strategy, Choice, InitializeCalldata } from "src/types.sol";
+import { IndexedStrategy, Proposal, Strategy, Choice, InitializeCalldata } from "../../types.sol";
 
 /// @title Space Events
 interface ISpaceEvents {

--- a/src/interfaces/space/ISpaceState.sol
+++ b/src/interfaces/space/ISpaceState.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.18;
 
-import { Choice, Proposal, ProposalStatus, FinalizationStatus, Strategy } from "src/types.sol";
-import { IExecutionStrategy } from "src/interfaces/IExecutionStrategy.sol";
+import { Choice, Proposal, ProposalStatus, FinalizationStatus, Strategy } from "../../types.sol";
+import { IExecutionStrategy } from "../../interfaces/IExecutionStrategy.sol";
 
 /// @title Space State
 interface ISpaceState {
@@ -63,6 +63,7 @@ interface ISpaceState {
     /// @return finalizationStatus The finalization status of the proposal. See `FinalizationStatus`.
     /// @return executionPayloadHash The keccak256 hash of the execution payload.
     /// @return activeVotingStrategies The bit array of the active voting strategies for the proposal.
+    /// @return selectedVotingStrategies
     function proposals(
         uint256 proposalId
     )
@@ -76,7 +77,8 @@ interface ISpaceState {
             uint32 maxEndBlockNumber,
             FinalizationStatus finalizationStatus,
             bytes32 executionPayloadHash,
-            uint256 activeVotingStrategies
+            uint256 activeVotingStrategies,
+            uint256 selectedVotingStrategies
         );
 
     /// @notice Returns the status of a proposal.

--- a/src/types.sol
+++ b/src/types.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.18;
 
 import { Enum } from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
-import { IExecutionStrategy } from "src/interfaces/IExecutionStrategy.sol";
+import { IExecutionStrategy } from "./interfaces/IExecutionStrategy.sol";
 
 /// @dev Constants used to replace the `bool` type in mappings for gas efficiency.
 uint256 constant TRUE = 1;
@@ -41,8 +41,6 @@ struct Proposal {
     // Bit array where the index of each bit corresponds to whether the voting strategy 
     // at that index was selected for the given proposal. empty array/0 indicates all active strategies are valid.
     uint256 selectedVotingStrategies;
-
-    uint8[] enumeratedVotingStrategies;
 }
 
 /// @notice The data stored for each strategy.

--- a/src/types.sol
+++ b/src/types.sol
@@ -37,6 +37,10 @@ struct Proposal {
     // Bit array where the index of each each bit corresponds to whether the voting strategy.
     // at that index is active at the time of proposal creation.
     uint256 activeVotingStrategies;
+    // SLOT 5:
+    // Bit array where the index of each bit corresponds to whether the voting strategy 
+    // at that index was selected for the given proposal. empty array/0 indicates all active strategies are valid.
+    uint256 selectedVotingStrategies;
 }
 
 /// @notice The data stored for each strategy.

--- a/src/types.sol
+++ b/src/types.sol
@@ -41,6 +41,8 @@ struct Proposal {
     // Bit array where the index of each bit corresponds to whether the voting strategy 
     // at that index was selected for the given proposal. empty array/0 indicates all active strategies are valid.
     uint256 selectedVotingStrategies;
+
+    uint8[] enumeratedVotingStrategies;
 }
 
 /// @notice The data stored for each strategy.

--- a/src/utils/SXUtils.sol
+++ b/src/utils/SXUtils.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.18;
 
-import { IndexedStrategy } from "src/types.sol";
+import { IndexedStrategy } from "../types.sol";
 
 /// @title Snapshot X Types Utilities Library
 library SXUtils {


### PR DESCRIPTION
### Description of Changes
- Allows proposers to more granularly select proposal's voting strategies from the set of active strategies
    - Adds a `uint8[]` function param to `propose` where caller can add indices of desired strategies per proposal
    - Uses `_getSelectedBitArray` internal function to compute a `uint256` bit array per standard 
    - Adds a `selectedVotingStrategies` to Proposal Struct
    - Creates a toggle to fallback to active proposal's if selected are not used prior to accumulating voting power(old behavior)
    
### Considerations
- Could check if active + selected strategies before using to allow for inactive strategies to not be used even when selected 

### Motivation
A project I'm working on has a need for different voting strategies per proposal and an attack vector occurs when users can select from all active strategies per proposal. The only current option to mitigate this is to deploy a space per proposal which seems inefficient