### PR TITLE
feat: merkle whitelist

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/openzeppelin/openzeppelin-contracts-upgradeable
 	branch = v4.8.0
+[submodule "lib/murky"]
+	path = lib/murky
+	url = https://github.com/dmfxyz/murky

--- a/remappings.txt
+++ b/remappings.txt
@@ -5,3 +5,4 @@ forge-gas-snapshot/=lib/forge-gas-snapshot/src
 @prb/test/=lib/prb-test/src/
 @zodiac/=lib/zodiac/contracts/
 @gnosis.pm/safe-contracts=lib/safe-contracts
+@murky/=lib/murky/src

--- a/src/voting-strategies/MerkleWhitelistVotingStrategy.sol
+++ b/src/voting-strategies/MerkleWhitelistVotingStrategy.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.18;
+
+import { MerkleProof } from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import { IVotingStrategy } from "../interfaces/IVotingStrategy.sol";
+
+/// @title Whitelist Voting Strategy
+/// @notice Allows a variable voting power whitelist that is stored in a merkle tree to be used for voting power.
+contract MerkleWhitelistVotingStrategy is IVotingStrategy {
+    /// @notice Error thrown when the proof submitted does not correspond to the `voter` address
+    error InvalidProof();
+
+    /// @dev The data for each member of the whitelist.
+    struct Member {
+        // The address of the member.
+        address addr;
+        // The voting power of the member.
+        uint96 vp;
+    }
+
+    /// @notice Returns the voting power of an address.
+    /// @param voter The address to get the voting power of.
+    /// @param params Parameter array containing the root the merkle tree containing the whitelist.
+    /// @param userParams Parameter array containing the desired member of the whitelist and its associated merkle proof.
+    /// @return votingPower The voting power of the address if it exists in the whitelist, otherwise reverts.
+    function getVotingPower(
+        uint32,
+        /* blockNumber */ address voter,
+        bytes calldata params,
+        bytes calldata userParams
+    ) external pure override returns (uint256 votingPower) {
+        bytes32 root = abi.decode(params, (bytes32));
+        (bytes32[] memory proof, Member memory member) = abi.decode(userParams, (bytes32[], Member));
+
+        MerkleProof.verify(proof, root, keccak256(abi.encode(member)));
+
+        if (member.addr != voter) revert();
+
+        return member.vp;
+    }
+}

--- a/test/MerkleWhitelistVotingStrategy.t.sol
+++ b/test/MerkleWhitelistVotingStrategy.t.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import { Test } from "forge-std/Test.sol";
+import { Merkle } from "@murky/Merkle.sol";
+import { MerkleWhitelistVotingStrategy } from "../src/voting-strategies/MerkleWhitelistVotingStrategy.sol";
+
+contract MerkleWhitelistVotingStrategyTest is Test {
+    error InvalidProof();
+    error InvalidMember();
+
+    MerkleWhitelistVotingStrategy public merkleWhitelistVotingStrategy;
+    Merkle public merkleLib;
+
+    function setUp() public {
+        merkleWhitelistVotingStrategy = new MerkleWhitelistVotingStrategy();
+        merkleLib = new Merkle();
+    }
+
+    function testMerkleWhitelistVotingPower() public {
+        MerkleWhitelistVotingStrategy.Member[] memory members = new MerkleWhitelistVotingStrategy.Member[](4);
+        members[0] = MerkleWhitelistVotingStrategy.Member(address(3), 33);
+        members[1] = MerkleWhitelistVotingStrategy.Member(address(1), 11);
+        members[2] = MerkleWhitelistVotingStrategy.Member(address(5), 55);
+        members[3] = MerkleWhitelistVotingStrategy.Member(address(5), 77);
+
+        bytes32[] memory leaves = new bytes32[](4);
+        leaves[0] = keccak256(abi.encode(members[0]));
+        leaves[1] = keccak256(abi.encode(members[1]));
+        leaves[2] = keccak256(abi.encode(members[2]));
+        leaves[3] = keccak256(abi.encode(members[3]));
+
+        bytes32 root = merkleLib.getRoot(leaves);
+
+        assertEq(
+            merkleWhitelistVotingStrategy.getVotingPower(
+                0,
+                members[0].addr,
+                abi.encode(root),
+                abi.encode(merkleLib.getProof(leaves, 0), members[0])
+            ),
+            members[0].vp
+        );
+        assertEq(
+            merkleWhitelistVotingStrategy.getVotingPower(
+                0,
+                members[1].addr,
+                abi.encode(root),
+                abi.encode(merkleLib.getProof(leaves, 1), members[1])
+            ),
+            members[1].vp
+        );
+        assertEq(
+            merkleWhitelistVotingStrategy.getVotingPower(
+                0,
+                members[2].addr,
+                abi.encode(root),
+                abi.encode(merkleLib.getProof(leaves, 2), members[2])
+            ),
+            members[2].vp
+        );
+        assertEq(
+            merkleWhitelistVotingStrategy.getVotingPower(
+                0,
+                members[3].addr,
+                abi.encode(root),
+                abi.encode(merkleLib.getProof(leaves, 3), members[3])
+            ),
+            members[3].vp
+        );
+    }
+
+    function testMerkleWhitelistInvalidProof() public {
+        MerkleWhitelistVotingStrategy.Member[] memory members = new MerkleWhitelistVotingStrategy.Member[](4);
+        members[0] = MerkleWhitelistVotingStrategy.Member(address(3), 33);
+        members[1] = MerkleWhitelistVotingStrategy.Member(address(1), 11);
+        members[2] = MerkleWhitelistVotingStrategy.Member(address(5), 55);
+        members[3] = MerkleWhitelistVotingStrategy.Member(address(5), 77);
+
+        bytes32[] memory leaves = new bytes32[](4);
+        leaves[0] = keccak256(abi.encode(members[0]));
+        leaves[1] = keccak256(abi.encode(members[1]));
+        leaves[2] = keccak256(abi.encode(members[2]));
+        leaves[3] = keccak256(abi.encode(members[3]));
+
+        bytes32 root = merkleLib.getRoot(leaves);
+
+        // Proof is empty
+        vm.expectRevert(InvalidProof.selector);
+        merkleWhitelistVotingStrategy.getVotingPower(
+            0,
+            members[0].addr,
+            abi.encode(root),
+            abi.encode(new bytes32[](0), members[0])
+        );
+    }
+
+    function testMerkleWhitelistInvalidMember() public {
+        MerkleWhitelistVotingStrategy.Member[] memory members = new MerkleWhitelistVotingStrategy.Member[](4);
+        members[0] = MerkleWhitelistVotingStrategy.Member(address(3), 33);
+        members[1] = MerkleWhitelistVotingStrategy.Member(address(1), 11);
+        members[2] = MerkleWhitelistVotingStrategy.Member(address(5), 55);
+        members[3] = MerkleWhitelistVotingStrategy.Member(address(5), 77);
+
+        bytes32[] memory leaves = new bytes32[](4);
+        leaves[0] = keccak256(abi.encode(members[0]));
+        leaves[1] = keccak256(abi.encode(members[1]));
+        leaves[2] = keccak256(abi.encode(members[2]));
+        leaves[3] = keccak256(abi.encode(members[3]));
+
+        bytes32 root = merkleLib.getRoot(leaves);
+
+        // Proof is for a different member than the voter address
+        vm.expectRevert(InvalidMember.selector);
+        merkleWhitelistVotingStrategy.getVotingPower(
+            0,
+            members[1].addr,
+            abi.encode(root),
+            abi.encode(merkleLib.getProof(leaves, 2), members[2])
+        );
+    }
+}


### PR DESCRIPTION
A voting strategy that allows a merkle tree based whitelist to be used for voting power. 