### PR TITLE
fix: validate merkletree using StandardMerkleTree format

### DIFF
--- a/src/voting-strategies/MerkleWhitelistVotingStrategy.sol
+++ b/src/voting-strategies/MerkleWhitelistVotingStrategy.sol
@@ -37,7 +37,9 @@ contract MerkleWhitelistVotingStrategy is IVotingStrategy {
         (bytes32[] memory proof, Member memory member) = abi.decode(userParams, (bytes32[], Member));
 
         if (member.addr != voter) revert InvalidMember();
-        if (MerkleProof.verify(proof, root, keccak256(abi.encode(member))) != true) revert InvalidProof();
+
+        bytes32 leaf = keccak256(bytes.concat(keccak256(abi.encode(member))));
+        if (MerkleProof.verify(proof, root, leaf) != true) revert InvalidProof();
 
         return member.vp;
     }

--- a/test/MerkleWhitelistVotingStrategy.t.sol
+++ b/test/MerkleWhitelistVotingStrategy.t.sol
@@ -25,10 +25,10 @@ contract MerkleWhitelistVotingStrategyTest is Test {
         members[3] = MerkleWhitelistVotingStrategy.Member(address(5), 77);
 
         bytes32[] memory leaves = new bytes32[](4);
-        leaves[0] = keccak256(abi.encode(members[0]));
-        leaves[1] = keccak256(abi.encode(members[1]));
-        leaves[2] = keccak256(abi.encode(members[2]));
-        leaves[3] = keccak256(abi.encode(members[3]));
+        leaves[0] = keccak256(bytes.concat(keccak256(abi.encode(members[0]))));
+        leaves[1] = keccak256(bytes.concat(keccak256(abi.encode(members[1]))));
+        leaves[2] = keccak256(bytes.concat(keccak256(abi.encode(members[2]))));
+        leaves[3] = keccak256(bytes.concat(keccak256(abi.encode(members[3]))));
 
         bytes32 root = merkleLib.getRoot(leaves);
 
@@ -78,10 +78,10 @@ contract MerkleWhitelistVotingStrategyTest is Test {
         members[3] = MerkleWhitelistVotingStrategy.Member(address(5), 77);
 
         bytes32[] memory leaves = new bytes32[](4);
-        leaves[0] = keccak256(abi.encode(members[0]));
-        leaves[1] = keccak256(abi.encode(members[1]));
-        leaves[2] = keccak256(abi.encode(members[2]));
-        leaves[3] = keccak256(abi.encode(members[3]));
+        leaves[0] = keccak256(bytes.concat(keccak256(abi.encode(members[0]))));
+        leaves[1] = keccak256(bytes.concat(keccak256(abi.encode(members[1]))));
+        leaves[2] = keccak256(bytes.concat(keccak256(abi.encode(members[2]))));
+        leaves[3] = keccak256(bytes.concat(keccak256(abi.encode(members[3]))));
 
         bytes32 root = merkleLib.getRoot(leaves);
 
@@ -103,10 +103,10 @@ contract MerkleWhitelistVotingStrategyTest is Test {
         members[3] = MerkleWhitelistVotingStrategy.Member(address(5), 77);
 
         bytes32[] memory leaves = new bytes32[](4);
-        leaves[0] = keccak256(abi.encode(members[0]));
-        leaves[1] = keccak256(abi.encode(members[1]));
-        leaves[2] = keccak256(abi.encode(members[2]));
-        leaves[3] = keccak256(abi.encode(members[3]));
+        leaves[0] = keccak256(bytes.concat(keccak256(abi.encode(members[0]))));
+        leaves[1] = keccak256(bytes.concat(keccak256(abi.encode(members[1]))));
+        leaves[2] = keccak256(bytes.concat(keccak256(abi.encode(members[2]))));
+        leaves[3] = keccak256(bytes.concat(keccak256(abi.encode(members[3]))));
 
         bytes32 root = merkleLib.getRoot(leaves);
 
@@ -131,7 +131,7 @@ contract MerkleWhitelistVotingStrategyTest is Test {
 
         bytes32[] memory leaves = new bytes32[](numMembers);
         for (uint256 i = 0; i < numMembers; i++) {
-            leaves[i] = keccak256(abi.encode(members[i]));
+            leaves[i] = keccak256(bytes.concat(keccak256(abi.encode(members[i]))));
         }
 
         bytes32 root = merkleLib.getRoot(leaves);


### PR DESCRIPTION
StandardMerkleTree format from official `@openzeppelin/merkle-tree` should be build using keccak hash of keccak hash of leaf data, instead of just keccak hash of leaf data as we do now.

This change makes it compatible with that library client side.

References:
- https://github.com/OpenZeppelin/merkle-tree#validating-a-proof-in-solidity
- https://github.com/OpenZeppelin/merkle-tree#standard-merkle-trees
> The leaves are double-hashed1 to prevent second preimage attacks.