### PR TITLE
refactor: simple quorum comment and var name

### DIFF
--- a/src/execution-strategies/SimpleQuorumExecutionStrategy.sol
+++ b/src/execution-strategies/SimpleQuorumExecutionStrategy.sol
@@ -34,7 +34,7 @@ abstract contract SimpleQuorumExecutionStrategy is IExecutionStrategy, SpaceMana
 
     /// @notice Returns the status of a proposal that uses a simple quorum.
     ///        A proposal is accepted if the for votes exceeds the against votes
-    ///        and a quorum of total votes (for + against + abstain) is reached.
+    ///        and a quorum of (for + abstain) votes is reached.
     /// @param proposal The proposal struct.
     /// @param votesFor The number of votes for the proposal.
     /// @param votesAgainst The number of votes against the proposal.
@@ -68,8 +68,8 @@ abstract contract SimpleQuorumExecutionStrategy is IExecutionStrategy, SpaceMana
     }
 
     function _quorumReached(uint256 _quorum, uint256 _votesFor, uint256 _votesAbstain) internal pure returns (bool) {
-        uint256 totalVotes = _votesFor + _votesAbstain;
-        return totalVotes >= _quorum;
+        uint256 forAndAbstainVotesTotal = _votesFor + _votesAbstain;
+        return forAndAbstainVotesTotal >= _quorum;
     }
 
     function _supported(uint256 _votesFor, uint256 _votesAgainst) internal pure returns (bool) {


### PR DESCRIPTION
The natspec comment mentioned that the quorum was calculated from all vote types when actually it is calculated from just for and abstain votes. 

Additionally, in the `_quorumReached` internal function, `totalVotes` was used as the variable name for the sum of for and abstain votes. This is misleading. 

This PR therefore updates the comment and renamed the `totalVotes` var to `forAndAbstainVotesTotal`.