### PR TITLE
feat: deployment fee

### DIFF
--- a/src/ProxyFactory.sol
+++ b/src/ProxyFactory.sol
@@ -4,12 +4,21 @@ pragma solidity ^0.8.18;
 
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { IProxyFactory } from "./interfaces/IProxyFactory.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
+address constant SPACE_IMPLEM = address(0xC3031A7d3326E47D49BfF9D374d74f364B29CE4D);
 
 /// @title Proxy Factory
 /// @notice A contract to deploy and track ERC1967 proxies of a given implementation contract.
-contract ProxyFactory is IProxyFactory {
+contract ProxyFactory is IProxyFactory, Ownable {
+    mapping(address implem => uint256 fee) public deploymentFees;
+
     /// @inheritdoc IProxyFactory
-    function deployProxy(address implementation, bytes memory initializer, uint256 saltNonce) external override {
+    function deployProxy(
+        address implementation,
+        bytes memory initializer,
+        uint256 saltNonce
+    ) external payable override {
         if (implementation == address(0) || implementation.code.length == 0) revert InvalidImplementation();
         bytes32 salt = keccak256(abi.encodePacked(msg.sender, saltNonce));
         if (predictProxyAddress(implementation, salt).code.length > 0) revert SaltAlreadyUsed();
@@ -17,6 +26,11 @@ contract ProxyFactory is IProxyFactory {
         // solhint-disable-next-line avoid-low-level-calls
         (bool success, ) = proxy.call(initializer);
         if (!success) revert FailedInitialization();
+
+        uint256 fee = deploymentFees[implementation];
+        if (fee > 0) {
+            if (msg.value < fee) revert InsufficientFee();
+        }
 
         emit ProxyDeployed(implementation, proxy);
     }
@@ -40,5 +54,16 @@ contract ProxyFactory is IProxyFactory {
                     )
                 )
             );
+    }
+
+    /// @inheritdoc IProxyFactory
+    function setDeploymentFee(address implem, uint256 fee) external onlyOwner {
+        deploymentFees[implem] = fee;
+        emit DeploymentFeeUpdated(implem, fee);
+    }
+
+    /// @notice Allows the owner to claim the fees collected by the contract.
+    function claimFees() external onlyOwner {
+        payable(owner()).transfer(address(this).balance);
     }
 }

--- a/src/ProxyFactory.sol
+++ b/src/ProxyFactory.sol
@@ -6,8 +6,6 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
 import { IProxyFactory } from "./interfaces/IProxyFactory.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
-address constant SPACE_IMPLEM = address(0xC3031A7d3326E47D49BfF9D374d74f364B29CE4D);
-
 /// @title Proxy Factory
 /// @notice A contract to deploy and track ERC1967 proxies of a given implementation contract.
 contract ProxyFactory is IProxyFactory, Ownable {

--- a/src/interfaces/IProxyFactory.sol
+++ b/src/interfaces/IProxyFactory.sol
@@ -11,10 +11,15 @@ interface IProxyFactory is IProxyFactoryErrors, IProxyFactoryEvents {
     /// @param implementation The address of the implementation contract.
     /// @param initializer ABI encoded function call to initialize the proxy.
     /// @param saltNonce a nonce used in combination with the sender's address and initializer to compute the salt.
-    function deployProxy(address implementation, bytes memory initializer, uint256 saltNonce) external;
+    function deployProxy(address implementation, bytes memory initializer, uint256 saltNonce) external payable;
 
     /// @notice Predicts the CREATE2 address of a proxy contract.
     /// @param implementation The address of the implementation contract.
     /// @param salt The CREATE2 salt used.
     function predictProxyAddress(address implementation, bytes32 salt) external view returns (address);
+
+    /// @notice Sets fee for deployment
+    /// @param implem The address of the implementation contract
+    /// @param fee The fee for deployment
+    function setDeploymentFee(address implem, uint256 fee) external;
 }

--- a/src/interfaces/factory/IProxyFactoryErrors.sol
+++ b/src/interfaces/factory/IProxyFactoryErrors.sol
@@ -12,4 +12,7 @@ interface IProxyFactoryErrors {
 
     /// @notice Thrown when the implementation supplied to the proxy factory is the zero address or has no code.
     error InvalidImplementation();
+
+    /// @notice Thrown when the deployment fee is insufficient.
+    error InsufficientFee();
 }

--- a/src/interfaces/factory/IProxyFactoryEvents.sol
+++ b/src/interfaces/factory/IProxyFactoryEvents.sol
@@ -8,4 +8,9 @@ interface IProxyFactoryEvents {
     /// @param implementation The address of the implementation contract.
     /// @param proxy The address of the proxy contract, determined via CREATE2.
     event ProxyDeployed(address implementation, address proxy);
+
+    /// @notice Emitted when the deployment fee for an implementation contract is updated.
+    /// @param implementation The address of the implementation contract.
+    /// @param fee The new deployment fee.
+    event DeploymentFeeUpdated(address implementation, uint256 fee);
 }


### PR DESCRIPTION
Adds a deployment fee upon space contract creation at the factory level.
The factory now has:
- An owner (along with `renounceOwnership`, `transferOwnership` etc).
- A function `setDeploymentFee(address implem, uint256 fee)` to set the fee for a particular implementation. Only the owner can call it.
- A function `claimFees()` that only the owner can call, that withdraws the current balance.

We also introduce some new errors and a new event `DeploymentFeeUpdated(address implem, uint256 fee)` to easily index it offchain.

Closes https://github.com/snapshot-labs/workflow/issues/398