### PR TITLE
fix: coverage issues with vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ forge test
 Get a test coverage report:
 
 ```sh
-$ forge coverage
+$ forge coverage --ir-minimum
 ```
 
 ### Deployment

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "clean": "rimraf cache out",
-    "coverage": "forge coverage --report lcov",
+    "coverage": "forge coverage --no-match-coverage testFork --ir-minimum --report lcov",
     "lint": "yarn lint:sol && yarn prettier:check",
     "lint:sol": "solhint \"{src,test,script}/**/*.sol\"",
     "prettier:check": "prettier --check \"**/*.{json,md,sol,yml}\"",

--- a/test/ActiveProposalsLimiterProposalValidationStrategy.t.sol
+++ b/test/ActiveProposalsLimiterProposalValidationStrategy.t.sol
@@ -65,7 +65,7 @@ contract ActiveProposalsLimterTest is SpaceTest {
         // max * 2 so we would revert if `cooldown` is not respected
         for (uint256 i = 0; i < maxActive * 2; i++) {
             _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
-            vm.warp(block.timestamp + cooldown);
+            vm.warp(vm.getBlockTimestamp() + cooldown);
         }
     }
 
@@ -110,19 +110,19 @@ contract ActiveProposalsLimterTest is SpaceTest {
         }
 
         // Advance until half of cooldown
-        vm.warp(block.timestamp + cooldown / 2);
+        vm.warp(vm.getBlockTimestamp() + cooldown / 2);
 
         // Should still fail
         vm.expectRevert(FailedToPassProposalValidation.selector);
         _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
 
         // Advance until ALMOST full cooldown has elapsed
-        vm.warp(block.timestamp + cooldown / 2 - 1);
+        vm.warp(vm.getBlockTimestamp() + cooldown / 2 - 1);
         vm.expectRevert(FailedToPassProposalValidation.selector);
         _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
 
         // Advance until full cooldown has elapsed
-        vm.warp(block.timestamp + 1);
+        vm.warp(vm.getBlockTimestamp() + 1);
         // We should be able to create `maxActive` proposals now
         for (uint256 i = 0; i < maxActive; i++) {
             _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));

--- a/test/AvatarExecutionStrategy.t.sol
+++ b/test/AvatarExecutionStrategy.t.sol
@@ -47,7 +47,7 @@ abstract contract AvatarExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit ProposalExecuted(proposalId);
@@ -67,7 +67,7 @@ abstract contract AvatarExecutionStrategyTest is SpaceTest {
             Strategy(address(avatarExecutionStrategy), abi.encode(transactions)),
             new bytes(0)
         );
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(abi.encodeWithSelector(InvalidProposalStatus.selector, ProposalStatus.Rejected));
         space.execute(proposalId, abi.encode(transactions));
@@ -83,7 +83,7 @@ abstract contract AvatarExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         transactions[0] = MetaTransaction(recipient, 2, "", Enum.Operation.Call, 0);
 
@@ -102,7 +102,7 @@ abstract contract AvatarExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(ExecutionFailed.selector);
         space.execute(proposalId, abi.encode(transactions));
@@ -126,7 +126,7 @@ abstract contract AvatarExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         assertEq(recipient.balance, 0); // sanity check
         assertEq(avatar.isModuleEnabled(address(0xbeef)), false); // sanity check
@@ -153,7 +153,7 @@ abstract contract AvatarExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(ExecutionFailed.selector);
         space.execute(proposalId, abi.encode(transactions));
@@ -246,7 +246,7 @@ abstract contract AvatarExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(InvalidSpace.selector);
         space.execute(proposalId, abi.encode(transactions));

--- a/test/CompTimelockExecutionStrategy.t.sol
+++ b/test/CompTimelockExecutionStrategy.t.sol
@@ -57,7 +57,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
         uint256 eta = block.timestamp + 1000;
         timelock.queueTransaction(address(timelock), 0, "", callData, eta);
 
-        vm.warp(block.timestamp + 1000);
+        vm.warp(vm.getBlockTimestamp() + 1000);
 
         timelock.executeTransaction(address(timelock), 0, "", callData, eta);
 
@@ -76,7 +76,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.warp(block.timestamp + space.maxVotingDuration());
+        vm.warp(vm.getBlockTimestamp() + space.maxVotingDuration());
 
         vm.expectRevert(InvalidSpace.selector);
         space.execute(proposalId, abi.encode(transactions));
@@ -92,7 +92,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -111,7 +111,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(DuplicateMetaTransaction.selector);
         space.execute(proposalId, abi.encode(transactions));
@@ -144,7 +144,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
         _vote(author, secondProposalId, Choice.For, userVotingStrategies, voteMetadataURI);
 
         // Move forward in time.
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         // Queue the first one: it should work properly.
         space.execute(firstProposalId, abi.encode(transactions));
@@ -163,7 +163,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             Strategy(address(timelockExecutionStrategy), abi.encode(transactions)),
             new bytes(0)
         );
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(abi.encodeWithSelector(InvalidProposalStatus.selector, ProposalStatus.Rejected));
         space.execute(proposalId, abi.encode(transactions));
@@ -179,7 +179,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -206,7 +206,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
         _vote(author, proposalId2, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -225,7 +225,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         transactions[0] = MetaTransaction(recipient, 2, "", Enum.Operation.Call, 0);
 
@@ -243,7 +243,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -251,7 +251,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
 
         assertEq(recipient.balance, 0);
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         assertEq(recipient.balance, 1);
@@ -267,11 +267,11 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
 
         vm.expectRevert("Timelock::executeTransaction: Transaction execution reverted.");
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
@@ -287,11 +287,11 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         transactions[0] = MetaTransaction(recipient, 2, "", Enum.Operation.Call, 0);
 
         vm.expectRevert(ProposalNotQueued.selector);
@@ -308,7 +308,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -328,7 +328,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(ProposalNotQueued.selector);
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
@@ -344,7 +344,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -352,7 +352,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
 
         assertEq(recipient.balance, 0);
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         vm.expectRevert(ProposalNotQueued.selector);
@@ -377,7 +377,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(InvalidTransaction.selector);
         space.execute(proposalId, abi.encode(transactions));
@@ -393,7 +393,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -408,7 +408,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
         emit ProposalVetoed(keccak256(abi.encode(transactions)));
         timelockExecutionStrategy.veto(abi.encode(transactions));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         vm.expectRevert(ProposalNotQueued.selector);
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
     }
@@ -423,7 +423,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -487,7 +487,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -495,7 +495,7 @@ abstract contract CompTimelockExecutionStrategyTest is SpaceTest {
 
         assertEq(erc721.ownerOf(1), address(timelock));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         assertEq(erc721.ownerOf(1), address(author));

--- a/test/CompVotingStrategy.t.sol
+++ b/test/CompVotingStrategy.t.sol
@@ -23,7 +23,7 @@ contract CompVotingStrategyTest is Test {
         compToken.mint(user, 1);
         // Must delegate to self to activate checkpoints
         compToken.delegate(user);
-        vm.roll(block.number + 1);
+        vm.roll(vm.getBlockNumber() + 1);
         assertEq(
             compVotingStrategy.getVotingPower(uint32(block.number), user, abi.encodePacked(address(compToken)), ""),
             1
@@ -33,7 +33,7 @@ contract CompVotingStrategyTest is Test {
     function testGetZeroVotingPower() public {
         compToken.mint(user, 1);
         // No delegation, so voting power is zero
-        vm.roll(block.number + 1);
+        vm.roll(vm.getBlockNumber() + 1);
         assertEq(
             compVotingStrategy.getVotingPower(uint32(block.number), user, abi.encodePacked(address(compToken)), ""),
             0
@@ -43,7 +43,7 @@ contract CompVotingStrategyTest is Test {
     function testGetVotingPowerInvalidToken() public {
         compToken.mint(user, 1);
         compToken.delegate(user);
-        vm.roll(block.number + 1);
+        vm.roll(vm.getBlockNumber() + 1);
         vm.expectRevert();
         // Token address is set to zero
         compVotingStrategy.getVotingPower(uint32(block.number), user, abi.encodePacked(address(0)), "");
@@ -52,7 +52,7 @@ contract CompVotingStrategyTest is Test {
     function testGetVotingPowerInvalidParamsArray() public {
         compToken.mint(user, 1);
         compToken.delegate(user);
-        vm.roll(block.number + 1);
+        vm.roll(vm.getBlockNumber() + 1);
         vm.expectRevert(InvalidByteArray.selector);
         // Params array is too short
         compVotingStrategy.getVotingPower(uint32(block.number), user, abi.encodePacked("1234"), "");

--- a/test/Deployer.t.sol
+++ b/test/Deployer.t.sol
@@ -25,6 +25,7 @@ contract DeployerTest is Test {
     function setUp() public {
         vm.setEnv("NETWORK", "test");
         vm.setEnv("DEPLOYER_ADDRESS", vm.toString(address(this)));
+        vm.setEnv("PRIVATE_KEY", vm.toString(uint256(1234)));
 
         // Setting the bytecode at the singleton address of the singleton factory.
         vm.etch(address(0xce0042B868300000d44A59004Da54A005ffdcf9f), singletonFactoryBytecode);

--- a/test/EmergencyQuorumExecutionStrategy.t.sol
+++ b/test/EmergencyQuorumExecutionStrategy.t.sol
@@ -115,7 +115,7 @@ contract EmergencyQuorumTest is SpaceTest {
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI); // 1
 
-        vm.roll(block.number + minVotingDuration);
+        vm.roll(vm.getBlockNumber() + minVotingDuration);
 
         vm.expectEmit(true, true, true, true);
         emit ProposalExecuted(proposalId);
@@ -131,7 +131,7 @@ contract EmergencyQuorumTest is SpaceTest {
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI); // 1
 
-        vm.roll(block.number + maxVotingDuration);
+        vm.roll(vm.getBlockNumber() + maxVotingDuration);
 
         vm.expectEmit(true, true, true, true);
         emit ProposalExecuted(proposalId);
@@ -156,7 +156,7 @@ contract EmergencyQuorumTest is SpaceTest {
         space.execute(proposalId, emergencyStrategy.params);
 
         // Now forward to `maxEndTimestamp`, the proposal should be finalized and `Rejected`.
-        vm.roll(block.number + maxVotingDuration);
+        vm.roll(vm.getBlockNumber() + maxVotingDuration);
 
         vm.expectRevert(abi.encodeWithSelector(InvalidProposalStatus.selector, uint8(ProposalStatus.Rejected)));
         space.execute(proposalId, emergencyStrategy.params);
@@ -175,7 +175,7 @@ contract EmergencyQuorumTest is SpaceTest {
             abi.encode(userVotingStrategies)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI); // emergencyQuorum reached
-        vm.roll(block.number + maxVotingDuration);
+        vm.roll(vm.getBlockNumber() + maxVotingDuration);
 
         vm.expectEmit(true, true, true, true);
         emit ProposalExecuted(proposalId);
@@ -224,7 +224,7 @@ contract EmergencyQuorumTest is SpaceTest {
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI); // 1
 
-        vm.roll(block.number + minVotingDuration);
+        vm.roll(vm.getBlockNumber() + minVotingDuration);
 
         space.execute(proposalId, emergencyStrategy.params);
 
@@ -290,7 +290,7 @@ contract EmergencyQuorumTest is SpaceTest {
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI); // 1
 
         // Warp to the minimum voting duration
-        vm.warp(block.timestamp + minVotingDuration);
+        vm.warp(vm.getBlockTimestamp() + minVotingDuration);
 
         // The proposal should not be executed because the new emergency quorum hasn't been reached yet.
         vm.expectRevert(abi.encodeWithSelector(InvalidProposalStatus.selector, ProposalStatus.VotingPeriod));

--- a/test/EthTxAuthenticator.t.sol
+++ b/test/EthTxAuthenticator.t.sol
@@ -145,7 +145,7 @@ contract EthTxAuthenticatorTest is SpaceTest {
         );
 
         // Fast forward and ensure everything is still working correctly
-        vm.roll(block.number + votingDelay);
+        vm.roll(vm.getBlockNumber() + votingDelay);
         vm.prank(voter);
         ethTxAuth.authenticate(
             address(space),

--- a/test/Execute.t.sol
+++ b/test/Execute.t.sol
@@ -10,7 +10,7 @@ contract ExecuteTest is SpaceTest {
     function testExecute() public {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration() + 1000);
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration() + 1000);
         vm.expectEmit(true, true, true, true);
         emit ProposalExecuted(proposalId);
         space.execute(proposalId, executionStrategy.params);
@@ -22,7 +22,7 @@ contract ExecuteTest is SpaceTest {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
         uint256 invalidProposalId = proposalId + 1;
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(abi.encodeWithSelector(InvalidProposal.selector));
         space.execute(invalidProposalId, executionStrategy.params);
@@ -31,7 +31,7 @@ contract ExecuteTest is SpaceTest {
     function testExecuteAlreadyExecuted() public {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
         space.execute(proposalId, executionStrategy.params);
 
         vm.expectRevert(abi.encodeWithSelector(ProposalFinalized.selector));
@@ -61,7 +61,7 @@ contract ExecuteTest is SpaceTest {
         vm.expectRevert(abi.encodeWithSelector(InvalidProposalStatus.selector, ProposalStatus.VotingPeriod));
         space.execute(proposalId, executionStrategy.params);
 
-        vm.roll(block.number + space.minVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.minVotingDuration());
         space.execute(proposalId, executionStrategy.params);
     }
 
@@ -74,7 +74,7 @@ contract ExecuteTest is SpaceTest {
 
     function testExecuteQuorumNotReachedAtAll() public {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(abi.encodeWithSelector(InvalidProposalStatus.selector, ProposalStatus.Rejected));
         space.execute(proposalId, executionStrategy.params);
@@ -85,7 +85,7 @@ contract ExecuteTest is SpaceTest {
     function testExecuteWithAgainstVote() public {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
         _vote(author, proposalId, Choice.Against, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(abi.encodeWithSelector(InvalidProposalStatus.selector, ProposalStatus.Rejected));
         space.execute(proposalId, executionStrategy.params);
@@ -96,7 +96,7 @@ contract ExecuteTest is SpaceTest {
     function testExecuteWithAbstainVote() public {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
         _vote(author, proposalId, Choice.Abstain, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(abi.encodeWithSelector(InvalidProposalStatus.selector, ProposalStatus.Rejected));
         space.execute(proposalId, executionStrategy.params);
@@ -115,7 +115,7 @@ contract ExecuteTest is SpaceTest {
     function testExecuteInvalidExecutionStrategy() public {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, Strategy(address(space), ""), new bytes(0));
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert();
         space.execute(proposalId, executionStrategy.params);

--- a/test/ForkedTests.t.sol
+++ b/test/ForkedTests.t.sol
@@ -47,7 +47,7 @@ contract ForkedTest is SpaceTest, SigUtils {
     function setUp() public virtual override {
         super.setUp();
 
-        string memory SEPOLIA_RPC_URL = vm.envString("SEPOLIA_RPC_URL");
+        string memory SEPOLIA_RPC_URL = "https://rpc.brovider.xyz/11155111";
         sepoliaFork = vm.createFork(SEPOLIA_RPC_URL);
 
         (voter2, key2) = makeAddrAndKey("Voter 2 Key");
@@ -164,7 +164,7 @@ contract ForkedTest is SpaceTest, SigUtils {
     function testFork_VoteAndProposeWithCompToken() public {
         vm.selectFork(sepoliaFork);
 
-        vm.roll(block.number + 1);
+        vm.roll(vm.getBlockNumber() + 1);
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(
             AUTHOR_KEY,

--- a/test/GasSnapshots.t.sol
+++ b/test/GasSnapshots.t.sol
@@ -154,7 +154,7 @@ contract GasSnapshotsTest is SpaceTest, SigUtils {
     }
 
     function testVoteAndProposeWithCompToken() public {
-        vm.roll(block.number + 1);
+        vm.roll(vm.getBlockNumber() + 1);
 
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(
             AUTHOR_KEY,

--- a/test/OZVotesVotingStrategy.t.sol
+++ b/test/OZVotesVotingStrategy.t.sol
@@ -23,7 +23,7 @@ contract OZVotesVotingStrategyTest is Test {
         erc20VotesToken.mint(user, 1);
         // Must delegate to self to activate checkpoints
         erc20VotesToken.delegate(user);
-        vm.roll(block.number + 1);
+        vm.roll(vm.getBlockNumber() + 1);
         assertEq(
             ozVotesVotingStrategy.getVotingPower(
                 uint32(block.number),
@@ -38,7 +38,7 @@ contract OZVotesVotingStrategyTest is Test {
     function testGetZeroVotingPower() public {
         erc20VotesToken.mint(user, 1);
         // No delegation, so voting power is zero
-        vm.roll(block.number + 1);
+        vm.roll(vm.getBlockNumber() + 1);
         assertEq(
             ozVotesVotingStrategy.getVotingPower(
                 uint32(block.number),
@@ -53,7 +53,7 @@ contract OZVotesVotingStrategyTest is Test {
     function testGetVotingPowerInvalidToken() public {
         erc20VotesToken.mint(user, 1);
         erc20VotesToken.delegate(user);
-        vm.roll(block.number + 1);
+        vm.roll(vm.getBlockNumber() + 1);
         vm.expectRevert();
         // Token address is set to zero
         ozVotesVotingStrategy.getVotingPower(uint32(block.number), user, abi.encodePacked(address(0)), "");
@@ -62,7 +62,7 @@ contract OZVotesVotingStrategyTest is Test {
     function testGetVotingPowerInvalidParamsArray() public {
         erc20VotesToken.mint(user, 1);
         erc20VotesToken.delegate(user);
-        vm.roll(block.number + 1);
+        vm.roll(vm.getBlockNumber() + 1);
         vm.expectRevert(InvalidByteArray.selector);
         // Params array is too short
         ozVotesVotingStrategy.getVotingPower(uint32(block.number), user, abi.encodePacked("1234"), "");

--- a/test/OptimisticCompTimelockExecutionStrategy.t.sol
+++ b/test/OptimisticCompTimelockExecutionStrategy.t.sol
@@ -58,7 +58,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
         uint256 eta = block.timestamp + 1000;
         timelock.queueTransaction(address(timelock), 0, "", callData, eta);
 
-        vm.warp(block.timestamp + 1000);
+        vm.warp(vm.getBlockTimestamp() + 1000);
 
         timelock.executeTransaction(address(timelock), 0, "", callData, eta);
 
@@ -77,7 +77,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.warp(block.timestamp + space.maxVotingDuration());
+        vm.warp(vm.getBlockTimestamp() + space.maxVotingDuration());
 
         vm.expectRevert(InvalidSpace.selector);
         space.execute(proposalId, abi.encode(transactions));
@@ -94,7 +94,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
         );
         // We do not cast a vote. The optimistic quorum should still accept the proposal
         // at the end of the voting period.
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -113,7 +113,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(DuplicateMetaTransaction.selector);
         space.execute(proposalId, abi.encode(transactions));
@@ -146,7 +146,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
         _vote(author, secondProposalId, Choice.For, userVotingStrategies, voteMetadataURI);
 
         // Move forward in time.
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         // Queue the first one: it should work properly.
         space.execute(firstProposalId, abi.encode(transactions));
@@ -166,7 +166,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.Against, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(abi.encodeWithSelector(InvalidProposalStatus.selector, ProposalStatus.Rejected));
         space.execute(proposalId, abi.encode(transactions));
@@ -182,7 +182,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -209,7 +209,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
         _vote(author, proposalId2, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -228,7 +228,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         transactions[0] = MetaTransaction(recipient, 2, "", Enum.Operation.Call, 0);
 
@@ -246,7 +246,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -254,7 +254,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
 
         assertEq(recipient.balance, 0);
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         assertEq(recipient.balance, 1);
@@ -270,11 +270,11 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
 
         vm.expectRevert("Timelock::executeTransaction: Transaction execution reverted.");
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
@@ -290,11 +290,11 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         transactions[0] = MetaTransaction(recipient, 2, "", Enum.Operation.Call, 0);
 
         vm.expectRevert(ProposalNotQueued.selector);
@@ -311,7 +311,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -331,7 +331,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(ProposalNotQueued.selector);
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
@@ -347,7 +347,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -355,7 +355,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
 
         assertEq(recipient.balance, 0);
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         vm.expectRevert(ProposalNotQueued.selector);
@@ -380,7 +380,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(InvalidTransaction.selector);
         space.execute(proposalId, abi.encode(transactions));
@@ -396,7 +396,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -411,7 +411,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
         emit ProposalVetoed(keccak256(abi.encode(transactions)));
         timelockExecutionStrategy.veto(abi.encode(transactions));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         vm.expectRevert(ProposalNotQueued.selector);
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
     }
@@ -426,7 +426,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -490,7 +490,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -498,7 +498,7 @@ abstract contract OptimisticCompTimelockExecutionStrategyTest is SpaceTest {
 
         assertEq(erc721.ownerOf(1), address(timelock));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         assertEq(erc721.ownerOf(1), address(author));

--- a/test/OptimisticQuorum.t.sol
+++ b/test/OptimisticQuorum.t.sol
@@ -58,7 +58,7 @@ contract OptimisticTest is SpaceTest {
 
     function testOptimisticQuorumNoVotes() public {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit ProposalExecuted(proposalId);
@@ -70,7 +70,7 @@ contract OptimisticTest is SpaceTest {
     function testOptimisticQuorumOneVote() public {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
         _vote(author, proposalId, Choice.Against, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit ProposalExecuted(proposalId);
@@ -83,7 +83,7 @@ contract OptimisticTest is SpaceTest {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
         _vote(author, proposalId, Choice.Against, userVotingStrategies, voteMetadataURI);
         _vote(address(42), proposalId, Choice.Against, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(abi.encodeWithSelector(InvalidProposalStatus.selector, ProposalStatus.Rejected));
         space.execute(proposalId, executionStrategy.params);
@@ -100,7 +100,7 @@ contract OptimisticTest is SpaceTest {
         _vote(address(11), proposalId, Choice.Against, userVotingStrategies, voteMetadataURI);
         _vote(address(12), proposalId, Choice.Against, userVotingStrategies, voteMetadataURI);
 
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(abi.encodeWithSelector(InvalidProposalStatus.selector, ProposalStatus.Rejected));
         space.execute(proposalId, executionStrategy.params);
@@ -113,7 +113,7 @@ contract OptimisticTest is SpaceTest {
         _vote(address(11), proposalId, Choice.Against, userVotingStrategies, voteMetadataURI);
         _vote(address(12), proposalId, Choice.Against, userVotingStrategies, voteMetadataURI);
 
-        vm.roll(block.number + space.minVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.minVotingDuration());
 
         vm.expectRevert(abi.encodeWithSelector(InvalidProposalStatus.selector, ProposalStatus.Rejected));
         space.execute(proposalId, executionStrategy.params);
@@ -124,7 +124,7 @@ contract OptimisticTest is SpaceTest {
     function testOptimisticQuorumMinVotingPeriodAccepted() public {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
 
-        vm.roll(block.number + space.minVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.minVotingDuration());
 
         space.execute(proposalId, executionStrategy.params);
 
@@ -153,7 +153,7 @@ contract OptimisticTest is SpaceTest {
             _vote(address(i), proposalId, Choice.Against, userVotingStrategies, voteMetadataURI);
         }
 
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(abi.encodeWithSelector(InvalidProposalStatus.selector, ProposalStatus.Rejected));
         space.execute(proposalId, executionStrategy.params);
@@ -173,7 +173,7 @@ contract OptimisticTest is SpaceTest {
         // Cast two votes against. This should be enough to trigger the old quorum but not the new one.
         _vote(author, proposalId, Choice.Against, userVotingStrategies, voteMetadataURI);
         _vote(address(42), proposalId, Choice.Against, userVotingStrategies, voteMetadataURI);
-        vm.warp(block.timestamp + space.maxVotingDuration());
+        vm.warp(vm.getBlockTimestamp() + space.maxVotingDuration());
 
         // vm.expectEmit(true, true, true, true);
         // emit ProposalExecuted(proposalId);

--- a/test/OptimisticTimelockExecutionStrategy.t.sol
+++ b/test/OptimisticTimelockExecutionStrategy.t.sol
@@ -62,7 +62,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(InvalidSpace.selector);
         space.execute(proposalId, abi.encode(transactions));
@@ -79,7 +79,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
         );
         // We do not cast a vote. The optimistic quorum should still accept the proposal
         // at the end of the voting period.
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -96,7 +96,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.Against, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert();
         space.execute(proposalId, abi.encode(transactions));
@@ -112,7 +112,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -139,7 +139,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
         _vote(author, proposalId2, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -168,7 +168,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
         _vote(author, proposalId2, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -185,7 +185,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         transactions[0] = MetaTransaction(recipient, 2, "", Enum.Operation.Call, 0);
 
@@ -203,7 +203,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -211,7 +211,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
 
         assertEq(recipient.balance, 0);
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         assertEq(recipient.balance, 1);
@@ -227,11 +227,11 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
 
         vm.expectRevert(ExecutionFailed.selector);
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
@@ -247,11 +247,11 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         transactions[0] = MetaTransaction(recipient, 2, "", Enum.Operation.Call, 0);
 
         vm.expectRevert(ProposalNotQueued.selector);
@@ -268,7 +268,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -288,7 +288,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(ProposalNotQueued.selector);
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
@@ -304,7 +304,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -312,7 +312,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
 
         assertEq(recipient.balance, 0);
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         vm.expectRevert(ProposalNotQueued.selector);
@@ -337,7 +337,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -345,7 +345,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
 
         assertEq(recipient.balance, 0);
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         assertEq(recipient.balance, 1);
@@ -376,7 +376,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -391,7 +391,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
         emit ProposalVetoed(keccak256(abi.encode(transactions)));
         timelockExecutionStrategy.veto(keccak256(abi.encode(transactions)));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         vm.expectRevert(ProposalNotQueued.selector);
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
     }
@@ -406,7 +406,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         // Set veto guardian
         address vetoGuardian = address(0x7e20);
@@ -427,7 +427,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -490,7 +490,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -499,7 +499,7 @@ abstract contract OptimisticTimelockExecutionStrategyTest is SpaceTest {
         assertEq(erc721.ownerOf(1), address(timelockExecutionStrategy));
         assertEq(erc1155.balanceOf(author, 1), 0);
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         assertEq(erc721.ownerOf(1), address(author));

--- a/test/SimpleQuorum.t.sol
+++ b/test/SimpleQuorum.t.sol
@@ -17,7 +17,7 @@ contract SimpleQuorumTest is SpaceTest {
 
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
 
-        vm.warp(block.timestamp + space.minVotingDuration());
+        vm.warp(vm.getBlockTimestamp() + space.minVotingDuration());
 
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI); // 1
 

--- a/test/TimelockExecutionStrategy.t.sol
+++ b/test/TimelockExecutionStrategy.t.sol
@@ -59,7 +59,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(InvalidSpace.selector);
         space.execute(proposalId, abi.encode(transactions));
@@ -75,7 +75,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -91,7 +91,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             Strategy(address(timelockExecutionStrategy), abi.encode(transactions)),
             new bytes(0)
         );
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert();
         space.execute(proposalId, abi.encode(transactions));
@@ -107,7 +107,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -134,7 +134,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
         _vote(author, proposalId2, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -163,7 +163,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
         _vote(author, proposalId2, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -180,7 +180,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         transactions[0] = MetaTransaction(recipient, 2, "", Enum.Operation.Call, 0);
 
@@ -198,7 +198,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -206,7 +206,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
 
         assertEq(recipient.balance, 0);
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         assertEq(recipient.balance, 1);
@@ -222,11 +222,11 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
 
         vm.expectRevert(ExecutionFailed.selector);
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
@@ -242,11 +242,11 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         transactions[0] = MetaTransaction(recipient, 2, "", Enum.Operation.Call, 0);
 
         vm.expectRevert(ProposalNotQueued.selector);
@@ -263,7 +263,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -283,7 +283,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectRevert(ProposalNotQueued.selector);
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
@@ -299,7 +299,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -307,7 +307,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
 
         assertEq(recipient.balance, 0);
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         vm.expectRevert(ProposalNotQueued.selector);
@@ -332,7 +332,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -340,7 +340,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
 
         assertEq(recipient.balance, 0);
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         assertEq(recipient.balance, 1);
@@ -371,7 +371,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -386,7 +386,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
         emit ProposalVetoed(keccak256(abi.encode(transactions)));
         timelockExecutionStrategy.veto(keccak256(abi.encode(transactions)));
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         vm.expectRevert(ProposalNotQueued.selector);
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
     }
@@ -401,7 +401,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         // Set veto guardian
         address vetoGuardian = address(0x7e20);
@@ -422,7 +422,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         space.execute(proposalId, abi.encode(transactions));
 
@@ -485,7 +485,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
             new bytes(0)
         );
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
 
         vm.expectEmit(true, true, true, true);
         emit TransactionQueued(transactions[0], block.timestamp + 1000);
@@ -494,7 +494,7 @@ abstract contract TimelockExecutionStrategyTest is SpaceTest {
         assertEq(erc721.ownerOf(1), address(timelockExecutionStrategy));
         assertEq(erc1155.balanceOf(author, 1), 0);
 
-        vm.warp(block.timestamp + timelockExecutionStrategy.timelockDelay());
+        vm.warp(vm.getBlockTimestamp() + timelockExecutionStrategy.timelockDelay());
         timelockExecutionStrategy.executeQueuedProposal(abi.encode(transactions));
 
         assertEq(erc721.ownerOf(1), address(author));

--- a/test/UpdateProposal.t.sol
+++ b/test/UpdateProposal.t.sol
@@ -58,14 +58,14 @@ contract UpdateProposalTest is SpaceTest {
         _updateProposal(author, proposalId, newStrategy, newMetadataURI);
 
         // Fast forward and finish the proposal to ensure everything is still working properly.
-        vm.roll(block.number + votingDelay);
+        vm.roll(vm.getBlockNumber() + votingDelay);
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
         space.execute(proposalId, executionStrategy.params);
     }
 
     function testUpdateFinalizedProposal() public {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
-        vm.roll(block.number + votingDelay);
+        vm.roll(vm.getBlockNumber() + votingDelay);
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
         space.execute(proposalId, executionStrategy.params);
 
@@ -75,7 +75,7 @@ contract UpdateProposalTest is SpaceTest {
 
     function testUpdateProposalAfterDelay() public {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
-        vm.roll(block.number + votingDelay);
+        vm.roll(vm.getBlockNumber() + votingDelay);
 
         vm.expectRevert(VotingDelayHasPassed.selector);
         // Try to update metadata. Should fail.

--- a/test/Vote.t.sol
+++ b/test/Vote.t.sol
@@ -52,7 +52,7 @@ contract VoteTest is SpaceTest {
     function testVoteVotingPeriodHasEnded() public {
         uint256 proposalId = _createProposal(author, proposalMetadataURI, executionStrategy, new bytes(0));
 
-        vm.roll(block.number + space.maxVotingDuration());
+        vm.roll(vm.getBlockNumber() + space.maxVotingDuration());
         vm.expectRevert(abi.encodeWithSelector(VotingPeriodHasEnded.selector));
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
     }
@@ -79,7 +79,7 @@ contract VoteTest is SpaceTest {
         vm.expectRevert(abi.encodeWithSelector(VotingPeriodHasNotStarted.selector));
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
 
-        vm.roll(block.number + space.votingDelay());
+        vm.roll(vm.getBlockNumber() + space.votingDelay());
         _vote(author, proposalId, Choice.For, userVotingStrategies, voteMetadataURI);
     }
 

--- a/test/VotingPowerProposalValidationStrategy.t.sol
+++ b/test/VotingPowerProposalValidationStrategy.t.sol
@@ -24,7 +24,7 @@ contract PropositionPowerProposalValidationTest is SpaceTest {
         compToken.mint(author, 100);
         vm.prank(author);
         compToken.delegate(author);
-        vm.roll(block.number + 1);
+        vm.roll(vm.getBlockNumber() + 1);
 
         Strategy memory compVotingStrategy = Strategy(
             address(new CompVotingStrategy()),
@@ -65,7 +65,7 @@ contract PropositionPowerProposalValidationTest is SpaceTest {
     function testProposeInsufficientVotingPower() public {
         vm.prank(author);
         compToken.burn(author, 1); // Voting power of the author is now 99 when the proposal threshold is 100
-        vm.roll(block.number + 1);
+        vm.roll(vm.getBlockNumber() + 1);
         vm.expectRevert(FailedToPassProposalValidation.selector);
         _createProposal(author, proposalMetadataURI, executionStrategy, abi.encode(userPropositionPowerStrategies));
     }


### PR DESCRIPTION
Fixes issues with running `forge coverage`.

Basically, had to use `vm.getBlockNumber()` and `vm.getBlockTimestamp()`. To do that, we had to update `forge-std`.
We also have to use `--ir-minimum` on coverage because we are getting some errors with stack too deep.
And we need to `--no-match-coverage` because of some issue with some forked tests. This test will still run, we just won't get any coverage on it (but it's a script to it doesn't matter).
