### PR TITLE
chore: convert absolute src/ imports to relative paths

### DIFF
--- a/src/Space.sol
+++ b/src/Space.sol
@@ -6,8 +6,8 @@ import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/O
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import { IERC4824 } from "src/interfaces/IERC4824.sol";
-import { ISpace, ISpaceActions, ISpaceState, ISpaceOwnerActions } from "src/interfaces/ISpace.sol";
+import { IERC4824 } from "./interfaces/IERC4824.sol";
+import { ISpace, ISpaceActions, ISpaceState, ISpaceOwnerActions } from "./interfaces/ISpace.sol";
 import {
     Choice,
     FinalizationStatus,
@@ -19,10 +19,10 @@ import {
     InitializeCalldata,
     TRUE,
     FALSE
-} from "src/types.sol";
-import { IVotingStrategy } from "src/interfaces/IVotingStrategy.sol";
-import { IExecutionStrategy } from "src/interfaces/IExecutionStrategy.sol";
-import { IProposalValidationStrategy } from "src/interfaces/IProposalValidationStrategy.sol";
+} from "./types.sol";
+import { IVotingStrategy } from "./interfaces/IVotingStrategy.sol";
+import { IExecutionStrategy } from "./interfaces/IExecutionStrategy.sol";
+import { IProposalValidationStrategy } from "./interfaces/IProposalValidationStrategy.sol";
 import { SXUtils } from "./utils/SXUtils.sol";
 import { BitPacker } from "./utils/BitPacker.sol";
 

--- a/src/interfaces/space/ISpaceActions.sol
+++ b/src/interfaces/space/ISpaceActions.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.18;
 
-import { Choice, IndexedStrategy, Strategy, InitializeCalldata } from "src/types.sol";
+import { Choice, IndexedStrategy, Strategy, InitializeCalldata } from "../../types.sol";
 
 /// @title Space Actions
 /// @notice User focused actions that can be performed on a space.

--- a/src/interfaces/space/ISpaceEvents.sol
+++ b/src/interfaces/space/ISpaceEvents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-import { IndexedStrategy, Proposal, Strategy, Choice, InitializeCalldata } from "src/types.sol";
+import { IndexedStrategy, Proposal, Strategy, Choice, InitializeCalldata } from "../../types.sol";
 
 /// @title Space Events
 interface ISpaceEvents {

--- a/src/interfaces/space/ISpaceState.sol
+++ b/src/interfaces/space/ISpaceState.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.8.18;
 
-import { Choice, Proposal, ProposalStatus, FinalizationStatus, Strategy } from "src/types.sol";
-import { IExecutionStrategy } from "src/interfaces/IExecutionStrategy.sol";
+import { Choice, Proposal, ProposalStatus, FinalizationStatus, Strategy } from "../../types.sol";
+import { IExecutionStrategy } from "../IExecutionStrategy.sol";
 
 /// @title Space State
 interface ISpaceState {

--- a/src/types.sol
+++ b/src/types.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.18;
 
 import { Enum } from "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
-import { IExecutionStrategy } from "src/interfaces/IExecutionStrategy.sol";
+import { IExecutionStrategy } from "./interfaces/IExecutionStrategy.sol";
 
 /// @dev Constants used to replace the `bool` type in mappings for gas efficiency.
 uint256 constant TRUE = 1;

--- a/src/utils/SXHash.sol
+++ b/src/utils/SXHash.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.18;
 
-import { IndexedStrategy, Strategy } from "src/types.sol";
+import { IndexedStrategy, Strategy } from "../types.sol";
 
 /// @title Snapshot X Types Hashing Library
 /// @notice For use in EIP712 signatures.

--- a/src/utils/SXUtils.sol
+++ b/src/utils/SXUtils.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.18;
 
-import { IndexedStrategy } from "src/types.sol";
+import { IndexedStrategy } from "../types.sol";
 
 /// @title Snapshot X Types Utilities Library
 library SXUtils {

--- a/src/utils/SignatureVerifier.sol
+++ b/src/utils/SignatureVerifier.sol
@@ -5,8 +5,8 @@ pragma solidity ^0.8.18;
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
-import { Choice, IndexedStrategy, Strategy } from "src/types.sol";
-import { SXHash } from "src/utils/SXHash.sol";
+import { Choice, IndexedStrategy, Strategy } from "../types.sol";
+import { SXHash } from "./SXHash.sol";
 import { TRUE, FALSE } from "../types.sol";
 
 /// @title EIP712 Signature Verifier


### PR DESCRIPTION
Problem
Several files in this repository use project-root-relative imports such as:
`import { IExecutionStrategy } from "src/interfaces/IExecutionStrategy.sol";`
These imports work when sx-evm is built standalone, but cause issues when the library is consumed as a dependency (e.g. via Foundry).

1. Tooling issues
Downstream projects must add a contextual remapping:
`lib/sx-evm/:src/=lib/sx-evm/src/` to allow solc to resolve the imports.

While compilation succeeds, some tooling does not appear to resolve contextual remappings in the same way as solc. For example, Foundry's Solar linter reports unresolved imports from sx-evm, forcing downstream projects to disable linting as a workaround.

2. Type conflicts
The repository currently mixes bare imports (src/types.sol) and relative imports (../types.sol) that resolve to the same file.
For example:
`SXUtils.sol` imports `IndexedStrategy` via `src/types.sol`
`PropositionPowerProposalValidationStrategy.sol` imports `IndexedStrategy` via `../types.sol`

When consumed downstream, solc can treat these as distinct source units, causing logically identical types to become incompatible and resulting in compilation errors such as:
```
TypeError: Member "assertNoDuplicateIndicesCalldata" not found or not visible after argument-dependent lookup
```
or
```
Invalid implicit conversion from struct InitializeCalldata memory to struct InitializeCalldata memory requested
```
Solution
Replace all bare `src/...` imports with relative imports.
Example:
```
import { IExecutionStrategy } from "./interfaces/IExecutionStrategy.sol";
```
Relative imports are self-contained, do not depend on repository-root assumptions, and work consistently whether sx-evm is built standalone or consumed as a dependency.
Impact:
- No functional changes.
- No ABI or bytecode changes.
- Removes the need for contextual remappings in downstream projects.
- Improves compatibility with tooling such as Solar.
- Prevents import-path-related type conflicts.
- No tests failing